### PR TITLE
provide second argument expression for all functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,58 +207,84 @@ are not further parsed, `<img>` tags does not need closing etc.
 
 ##### xml
 
-`zu.xml(nodes)`
+`zu.xml(nodes, exp)`
 
-Turn given array of nodes into a string XML form.
+Turn given array of nodes into a string XML form. Optionally prefilters
+the nodes using an expression.
 
+* `:: ns, s -> s`
 * `:: ns -> s`
+
+Also `zu.xmlWith(nodes or exp)`
+
+* `:: s  -> ns -> s`
+* `:: ns -> s  -> s`
 
 ##### html
 
 `zu.html(nodes)`
 
-Turn given array of nodes into a string HTML form.
+Turn given array of nodes into a string HTML form. Optionally prefilters
+the nodes using an expression.
 
+* `:: ns, s -> s`
 * `:: ns -> s`
+
+Also `zu.htmlWith(nodes or exp)`
+
+* `:: s  -> ns -> s`
+* `:: ns -> s  -> s`
 
 ##### text
 
-`zu.text(nodes)`
+`zu.text(nodes, exp)`
 
-Turn given array of text nodes into a string, where the
-contents of each node is concatenated together.
+Turn given array of text nodes into a string, where the contents of
+each node is concatenated together. Optionally prefilters the nodes
+using an expression.
 
+* `:: ns, s -> s`
 * `:: ns -> s`
+
+Also `zu.textWith(nodes or exp)`
+
+* `:: s  -> ns -> s`
+* `:: ns -> s  -> s`
 
 ##### attr
 
-`zu.attr(nodes, name)`
+`zu.attr(nodes, exp, name)`
 
 Return the attribute value for `names` from the first element in the
-given array of nodes.
+given array of nodes. Optionaly filters the nodes using the given
+expression.
 
 * `:: ns, s -> s`
+* `:: ns, s, s -> s`
 
 Also `zu.attrWith(nodes or name)`
 
 * `:: ns -> s  -> s`
+* `:: ns, s -> s  -> s`
 * `:: s  -> ns -> s`
+* `:: s  -> ns, s -> s`
 
 ##### hasClass
 
+`zu.hasClass(nodes, exp, name)`
+
 Test whether any node in the given array of nodes has a `name` as a
-class.
+class. Optionally filters the expression using expression.
 
-`zu.hasClass(nodes, name)`
-
-* `:: ns, s -> s`
+* `:: ns, s -> bool`
+* `:: ns, s, s -> bool`
 
 Also `zu.hasClassWith(nodes or name)`
 
-* `:: ns -> s  -> s`
-* `:: s  -> ns -> s`
-
-
+* `:: ns -> s  -> bool`
+* `:: ns, s -> s  -> bool`
+* `:: s  -> ns -> bool`
+* `:: s  -> ns, s -> bool`
 
 ### Selectors
 

--- a/src/domparser.coffee
+++ b/src/domparser.coffee
@@ -49,8 +49,10 @@ output = (fn, opts) -> (nodes) ->
     fn nodes, opts
 
 module.exports =
-    parseXml:  (s) -> doparse s, {xmlMode:true}
-    parseHtml: (s) -> doparse s
-    xml:  output serialize, xmlMode:true
-    html: output serialize
-    text: output renderText
+    parse:
+        parseXml:  (s) -> doparse s, {xmlMode:true}
+        parseHtml: (s) -> doparse s
+    output:
+        xml:  output serialize, xmlMode:true
+        html: output serialize
+        text: output renderText

--- a/src/matcher.coffee
+++ b/src/matcher.coffee
@@ -2,7 +2,7 @@
 filter    = require './filter'
 escre     = require './escre'
 hasclass  = require './hasclass'
-domparser = require './domparser'
+{text}    = require('./domparser').output
 
 isId = (n, id) -> n.attribs?.id == id
 onlytag = (as) -> filter as, (n) -> n.type == 'tag'
@@ -30,7 +30,7 @@ evlattr = (n, ast) ->
 # evaluate pseudo selector
 evlpseudo = (n, ast) ->
     if ast.pseudotype == 'contains'
-        domparser.text(n).indexOf(ast.pseudoval) >= 0
+        text(n).indexOf(ast.pseudoval) >= 0
     else if ast.pseudotype == 'empty'
         !n?.children?.length or !firstfn n.children, (c) -> c.type == 'tag' or c.type == 'text'
     else if ast.pseudotype == 'first-child'

--- a/src/zu.coffee
+++ b/src/zu.coffee
@@ -1,25 +1,56 @@
-{zipwith, set, mixin, keys, values, converge, map, apply} = require 'fnuc'
+{zipwith, set, mixin, keys, values, converge, map, apply, arityof} = require 'fnuc'
+domparser = require './domparser'
+selectors = require './selectors'
 hasclass  = require './hasclass'
+
+# for a function fn that just accept nodes, give an extra argument
+# (nodes, exp) that, if present, performs a selectors.find on that
+# expression.
+preselector  = (fn) -> (nodes, exp) ->
+    nodes = if exp then selectors.find(nodes, exp) else nodes
+    fn nodes
+
+# for a function fn that accepts nodes and something more, gives
+# extra arguments (nodes, exp, a3) that, if present, performs
+# a selectors.find on that expression.
+preselector3 = (fn) -> (nodes, exp, a3) ->
+    if arguments.length == 2
+        a3 = exp
+        exp = undefined
+    nodes = if exp then selectors.find(nodes, exp) else nodes
+    fn nodes, a3
 
 # fn can be partially applied either with an array or an expression.
 withcurry = (fn) -> (a) ->
     if a.constructor == String then ((ns)  -> fn ns, a) else ((exp) -> fn a, exp)
+
+# fn can be partially applied with an array + optional expression and then a string arg
+withprecurry = (fn) -> (a, a2) ->
+    if a.constructor == String then ((ns, exp) -> fn ns, exp, a) else ((a3) -> fn a, a2, a3)
+
+# for an object a:fn make an object [{a:preselector(fn)}]
+preselectify = do ->
+    z = (k, fn) -> set {}, k, preselector(fn)
+    converge zipwith(z), keys, values
 
 # key fooWith for foo
 withk = (s) -> "#{s}With"
 
 # for an object a:fn make an object with [{a:fn, aWith:withcurry(fn)}]
 # for each k/v pair.
-withify = do ->
-    z = (k, fn) -> set(withk(k), withcurry(fn)) set({}, k, fn)
+withify = (curryfn) ->
+    z = (k, fn) -> set(withk(k), curryfn(fn)) set({}, k, fn)
     converge zipwith(z), keys, values
 
-arg1 = require './domparser'
+arg1 = domparser.parse
 
-arg2 = mixin {
-    attr:      (ns, name) -> (if Array.isArray(ns) then ns[0] else ns)?.attribs?[name]
-    hasClass:  (ns, name) -> return true for n in ns when hasclass(n, name); return false
-    }, require './selectors'
+arg2 = mixin selectors, (mixin preselectify(domparser.output)...)
+
+arg2str =
+    attr:     preselector3 (ns, name) ->
+        (if Array.isArray(ns) then ns[0] else ns)?.attribs?[name]
+    hasClass: preselector3 (ns, name) ->
+        return true for n in ns when hasclass(n, name); return false
 
 
-module.exports = zu = mixin arg1, withify(arg2)...
+module.exports = zu = mixin arg1, withify(withcurry)(arg2)..., withify(withprecurry)(arg2str)...

--- a/test/test-misc.coffee
+++ b/test/test-misc.coffee
@@ -23,6 +23,14 @@ describe 'attr', ->
     it 'accepts non arrays', ->
         assert.equal zu.attr(zu.find(ns,'img')[0],'src'), 'foo1.jpg'
 
+    it 'optionally filters using expression', ->
+        assert.equal zu.attr(ns, 'img', 'src'), 'foo1.jpg'
+
+    it 'optionally filters using expression in With-version', ->
+        assert.equal zu.attrWith(ns, 'img')('src'), 'foo1.jpg'
+        assert.equal zu.attrWith('src')(ns, 'img'), 'foo1.jpg'
+
+
 describe 'hasClass', ->
 
     it 'checks whether any of the matched elements has the class', ->
@@ -31,6 +39,14 @@ describe 'hasClass', ->
 
     it 'returns false if none has the class', ->
         assert.equal zu.hasClass(zu.find(ns,'img'),'nosuchclass'), false
+
+    it 'optionally filters using expression', ->
+        assert.equal zu.hasClass(ns, 'img', 'c'), true
+
+    it 'optionally filters using expression in With-version', ->
+        assert.equal zu.hasClassWith(ns, 'img')('c'), true
+        assert.equal zu.hasClassWith('c')(ns, 'img'), true
+
 
 describe 'namespaces', ->
 

--- a/test/test-render.coffee
+++ b/test/test-render.coffee
@@ -27,6 +27,9 @@ describe 'xml', ->
     it 'is ok with null', ->
         assert.equal zu.xml(null), ''
 
+    it 'takes an optional expression', ->
+        assert.equal zu.xml(ns, 'img'), '<img src="foo.jpg"/>'
+
 describe 'html', ->
 
     it 'renders output as html', ->
@@ -39,6 +42,9 @@ describe 'html', ->
     it 'is ok with null', ->
         assert.equal zu.html(null), ''
 
+    it 'takes an optional expression', ->
+        assert.equal zu.html(ns, 'img'), '<img src="foo.jpg">'
+
 describe 'text', ->
 
     it 'renders output as text', ->
@@ -50,3 +56,6 @@ describe 'text', ->
 
     it 'accepts undefined', ->
         assert.equal zu.text(undefined), ''
+
+    it 'takes an optional expression', ->
+        assert.equal zu.text(ns, 'span'), 'foo'


### PR DESCRIPTION
I really want a second filtering expression in `zu.text()`. I find myself repeating this over and over again:

```
zu.text(zu.find(ns, 'something'))
```

So on a simplistic level this whole commit started doing for `xml`, `html` and `text`:

```
zu.text(ns, 'something)
```

However then the rabbit hole opened. Because why wouldn't there be a filtering expression to `zu.attr`

```
zu.attr(ns, 'something', 'attrname')
```

And that in turn lead to having to sort out the curried expressions as 2+1-arg versions:

```
zu.attr(ns, 'something')('attrname')
zu.attr('attrname')(ns, 'something)
```

So that is all done now for `xml`, `html`, `text`, `attr` and `hasClass`. But then I started hesitating. A lot of complexity, for what? I can solve this by simple function composition in my project using zu?
